### PR TITLE
Fix backup and restore of graph

### DIFF
--- a/src/app/components/basecontrol/basecontrol.component.html
+++ b/src/app/components/basecontrol/basecontrol.component.html
@@ -40,8 +40,7 @@
 <ng-template #string let-value="value" let-index="index">
 
   <ng-container *ngIf="!data.multiline; else stringMulti">
-    <input type="text" class="w-full cid-input" (keydown.escape)="onChange($event, index)"
-      (keydown.enter)="onChange($event, index)" [class.cid-required]="isEmpty()" (blur)="onChange($event, index)"
+    <input type="text" class="w-full cid-input" (keydown)="onChange($event, index)" [class.cid-required]="isEmpty()"
       autocomplete="off" [placeholder]="data.hint || ''" [value]="value" [readonly]="isReadOnly()" />
   </ng-container>
 
@@ -58,9 +57,8 @@
 </ng-template>
 
 <ng-template #number let-value="value">
-  <input #input type="number" (keydown.escape)="onChange($event)" (keydown.enter)="onChange($event)"
-    (blur)="onChange($event)" [value]="value" [readonly]="isReadOnly()" [title]="value" [step]="data.step "
-    placeholder=" " />
+  <input #input type="number" (keydown)="onChange($event)" [value]="value" [readonly]="isReadOnly()" [title]="value"
+    [step]="data.step " placeholder=" " />
 </ng-template>
 
 <ng-template #arrayBoolean let-value="value">

--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -4,7 +4,7 @@ import { Output, Socket } from 'rete/_types/presets/classic';
 import { BaseConnection } from 'src/app/helper/rete/baseconnection';
 import { BaseNode } from 'src/app/helper/rete/basenode';
 import { BaseSocket } from 'src/app/helper/rete/basesocket';
-import { Schemes, area, arrange, createEditor, editor, readonly } from 'src/app/helper/rete/editor';
+import { Schemes, g_area, g_arrange, createEditor, g_editor, readonly, AreaExtra } from 'src/app/helper/rete/editor';
 import { IGraph, INode } from 'src/app/schemas/graph';
 import { GraphService, Origin } from 'src/app/services/graph.service';
 import { NodeFactory } from 'src/app/services/nodefactory.service';
@@ -26,6 +26,7 @@ import { featherSearch } from '@ng-icons/feather-icons';
 import { SocketData } from 'rete-connection-plugin';
 import { BaseInput } from 'src/app/helper/rete/baseinput';
 import { BaseOutput } from 'src/app/helper/rete/baseoutput';
+import { Area2D } from 'rete-area-plugin';
 
 provideVSCodeDesignSystem().register(
   // vsCodeButton(),
@@ -44,9 +45,11 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   nf = inject(NodeFactory);
   ns = inject(NotificationService);
   gw = inject(GatewayService);
+
   injector = inject(Injector);
   yamlService = inject(YamlService);
   vscode = inject(VsCodeService);
+  cdr = inject(ChangeDetectorRef);
 
   @ViewChild('rete') container!: ElementRef<HTMLElement>;
 
@@ -175,7 +178,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
         break;
       }
       case 'getFileData': {
-        const graph = this.gs.serializeGraph(editor!, area!, '');
+        const graph = this.gs.serializeGraph(g_editor!, g_area!, '');
         this.vscode.postMessage({ type: 'callbackResponse', requestId, data: graph });
         break;
       }
@@ -246,7 +249,8 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.messageSubscription.unsubscribe()
+    this.messageSubscription.unsubscribe();
+    console.log("ngOnDestroy")
   }
 
   async onCreateNode(_event: MouseEvent, nodeTypeId: string): Promise<void> {
@@ -254,26 +258,29 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   async createAndAddNodes(node: INode, nodes: Map<string, BaseNode>): Promise<void> {
-    const n = await this.nf.createNode(node.id, node.type, node.inputs, node.outputs);
+    const n = await this.gs.createNode(node.type, false, node.inputs, node.outputs);
     if (node.settings) {
       n.setSettings(node.settings);
     }
 
-    await editor!.addNode(n);
-
     if (node.position?.x > 0 && node.position?.y > 0) {
-      await area!.translate(n.id, node.position);
+      await g_area!.translate(n.id, node.position);
     }
 
     nodes.set(node.id, n);
   }
 
   async loadGraphToEditor(graph: IGraph): Promise<void> {
-    if (!editor) {
+    if (!g_editor) {
       throw new Error('Editor not initialized');
     }
 
-    await editor.clear();
+    await g_editor.clear();
+
+    if (graph.view) {
+      await g_area!.area.zoom(graph.view.transform.k, 0, 0);
+      await g_area!.area.translate(graph.view.transform.x, graph.view.transform.y);
+    }
 
     await this.nr.loadFullNodeTypeDefinitions(new Set(graph.nodes.map(n => n.type)));
 
@@ -299,7 +306,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
 
         if (srcSocket !== undefined && dstSocket !== undefined) {
           const c = new BaseConnection(sourceNode, srcSocket.socket as BaseSocket, targetNode, dstSocket.socket as BaseSocket);
-          createConnections.push(editor.addConnection(c))
+          createConnections.push(g_editor.addConnection(c))
 
         }
       }
@@ -316,7 +323,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
 
         if (srcSocket !== undefined && dstSocket !== undefined) {
 
-          const promise = editor.addConnection(new BaseConnection(sourceNode, srcSocket.socket as BaseSocket, targetNode, dstSocket.socket as BaseSocket));
+          const promise = g_editor.addConnection(new BaseConnection(sourceNode, srcSocket.socket as BaseSocket, targetNode, dstSocket.socket as BaseSocket));
           createConnections.push(promise);
         }
       }
@@ -325,11 +332,9 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
     await Promise.all(createConnections);
 
     for (const node of nodes.values()) {
-      void area!.update("node", node.id);
+      void g_area!.update("node", node.id);
     }
   }
-
-  cdr = inject(ChangeDetectorRef);
 
   async ngAfterViewInit() {
 
@@ -393,34 +398,27 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
       return context;
     });
 
-    editor.addPipe((context: Root<Schemes>) => {
-      const { type, data } = context as { type: string, data: { id: string, source: string, sourceOutput: string } };
-      switch (type) {
-        case "connectioncreated": {
-          console.log("Connection created")
-          const node: BaseNode | undefined = editor.getNode(data.source);
-          if (node) {
-            node.addOutgoingConnection(data.sourceOutput);
-          }
-          break;
-        }
-        case "connectionremoved": {
-          console.log("Connection removed")
-          const node: BaseNode | undefined = editor.getNode(data.source)
-          if (node) {
-            node.removeOutgoingConnection(data.sourceOutput);
-          }
-          break;
-        }
-      }
-      return context;
-    });
-
     if (environment.vscode) {
+
+      area.addPipe((context: Root<Schemes> | AreaExtra | Area2D<Schemes>) => {
+        const { type } = context as { type: string };
+        switch (type) {
+          case "pointerup": // finish dragging
+          case "nodedragged": {
+            if (!this.loading) {
+              const graph = this.gs.serializeGraph(editor, area!, '');
+              void this.vscode.postMessage({ type: 'saveGraph', requestId: -1, data: graph });
+            }
+            break;
+          }
+        }
+        return context;
+      })
 
       editor.addPipe((context: Root<Schemes>) => {
         const { type } = context as { type: string };
         switch (type) {
+          case "nodetranslated":
           case "nodecreated":
           case "noderemoved":
           case "connectioncreated":
@@ -432,7 +430,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
             // send the 'saveGraph' message outside of the loading operation.
             if (!this.loading) {
               const graph = this.gs.serializeGraph(editor, area!, '');
-              this.vscode.postMessage({ type: 'saveGraph', requestId: -1, data: graph });
+              void this.vscode.postMessage({ type: 'saveGraph', requestId: -1, data: graph });
             }
             break;
           }
@@ -465,6 +463,6 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   async arrangeNodes(): Promise<void> {
-    await arrange!.layout();
+    await g_arrange!.layout();
   }
 }

--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -250,7 +250,6 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.messageSubscription.unsubscribe();
-    console.log("ngOnDestroy")
   }
 
   async onCreateNode(_event: MouseEvent, nodeTypeId: string): Promise<void> {
@@ -365,7 +364,6 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
       switch (type) {
         case "connectionpick": {
           const { data } = context as unknown as { data: { socket: SocketData } };
-          console.log("Connection picked on socket");
           const node: BaseNode | undefined = editor.getNode(data.socket.nodeId);
           if (node) {
             node.addOutgoingConnection(data.socket.key);
@@ -377,13 +375,11 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
           if (data.socket) {
             // Use the node id, depending on where the connection was dropped.
             // Either on the socket of the output node, or on the socket of the input node.
-            console.log("Connection dropped on socket");
             const node: BaseNode | undefined = editor.getNode(data.initial.side === 'output' ? data.initial.nodeId : data.socket.nodeId);
             if (node) {
               node.removeOutgoingConnection(data.initial.key);
             }
           } else {
-            console.log("Connection dropped on empty space");
             const node: BaseNode | undefined = editor.getNode(data.initial.nodeId);
             if (node) {
               node.removeOutgoingConnection(data.initial.key);

--- a/src/app/components/rete/node/basenode.component.ts
+++ b/src/app/components/rete/node/basenode.component.ts
@@ -12,7 +12,7 @@ import { BaseControl, BaseControlType } from "src/app/helper/rete/basecontrol";
 import { BaseInput } from "src/app/helper/rete/baseinput";
 import { BaseNode } from "src/app/helper/rete/basenode";
 import { BaseOutput } from "src/app/helper/rete/baseoutput";
-import { area, editor } from "src/app/helper/rete/editor";
+import { g_area, g_editor } from "src/app/helper/rete/editor";
 import { GraphService } from "src/app/services/graph.service";
 import { NodeFactory } from "src/app/services/nodefactory.service";
 import { Registry } from "src/app/services/registry.service";
@@ -68,24 +68,24 @@ export class BaseNodeComponent implements OnChanges {
     this.cdr.detach();
   }
 
-  isCompact(): boolean {
-    return this.data.getDefinition().compact;
-  }
-
   ngOnChanges(): void {
     this.cdr.detectChanges();
     requestAnimationFrame(() => this.rendered());
     this.seed++; // force render sockets
   }
 
+  isCompact(): boolean {
+    return this.data.getDefinition().compact;
+  }
+
   async onShowHideConnectedPorts(event: MouseEvent): Promise<void> {
     event.stopPropagation();
     event.preventDefault();
 
-    const n = editor!.getNode(this.data.id);
+    const n = g_editor!.getNode(this.data.id);
     n.getSettings().folded = Boolean(!n.getSettings().folded);
 
-    await area!.update("node", this.data.id);
+    await g_area!.update("node", this.data.id);
     this.cdr.detectChanges();
   }
 
@@ -101,20 +101,20 @@ export class BaseNodeComponent implements OnChanges {
 
     await this.data.appendOutputValue(output);
 
-    await area!.update("node", this.data.id);
+    await g_area!.update("node", this.data.id);
     this.cdr.detectChanges();
   }
 
   async onAppendInputValue(event: MouseEvent, input: BaseInput): Promise<void> {
     event.stopPropagation();
 
-    await this.data.appendInputValue(input);
+    await this.data.appendInputValue(input, this.gs.inputChangeSuject());
 
     const control = input.control as BaseControl<BaseControlType> | null;
     if (control) {
-      await area!.update("control", control.id);
+      await g_area!.update("control", control.id);
     }
-    await area!.update("node", this.data.id);
+    await g_area!.update("node", this.data.id);
     this.cdr.detectChanges();
   }
 
@@ -122,7 +122,7 @@ export class BaseNodeComponent implements OnChanges {
     event.stopPropagation();
 
     await this.data.popOutputValue(output);
-    await area!.update("node", this.data.id);
+    await g_area!.update("node", this.data.id);
     this.cdr.detectChanges();
   }
 
@@ -132,9 +132,9 @@ export class BaseNodeComponent implements OnChanges {
     await this.data.popInputValue(input);
     const control = input.control as BaseControl<BaseControlType> | null;
     if (control) {
-      await area!.update("control", control.id);
+      await g_area!.update("control", control.id);
     }
-    await area!.update("node", this.data.id);
+    await g_area!.update("node", this.data.id);
     this.cdr.detectChanges();
   }
 

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -9,7 +9,7 @@ import { provideVSCodeDesignSystem, vsCodeButton } from "@vscode/webview-ui-tool
 import { getErrorMessage } from 'src/app/helper/utils';
 import { environment } from 'src/environments/environment';
 import { Clipboard } from '@angular/cdk/clipboard';
-import { area, editor } from 'src/app/helper/rete/editor';
+import { g_area, g_editor } from 'src/app/helper/rete/editor';
 
 provideVSCodeDesignSystem().register(vsCodeButton());
 
@@ -36,7 +36,7 @@ export class SidebarComponent {
   }
 
   onCopyToClipboard(_event: MouseEvent): void {
-    const graph = this.gs.serializeGraph(editor!, area!, "Dev");
+    const graph = this.gs.serializeGraph(g_editor!, g_area!, "Dev");
     this.clipboard.copy(graph);
   }
 

--- a/src/app/helper/rete/basecontrol.ts
+++ b/src/app/helper/rete/basecontrol.ts
@@ -61,10 +61,6 @@ export class BaseControl<T extends BaseControlType | unknown, N =
         this.required = opts?.required;
         this.options = opts?.options;
         this.default = opts.default;
-
-        if (typeof opts.default !== 'undefined') {
-            this.setValue(opts.default);
-        }
     }
 
     getValue(): N {

--- a/src/app/helper/rete/editor.ts
+++ b/src/app/helper/rete/editor.ts
@@ -34,9 +34,9 @@ export type Schemes = GetSchemes<BaseNode, Conn>;
 export type AreaExtra = AngularArea2D<Schemes>;
 
 export const readonly = new ReadonlyPlugin<Schemes>();
-export let editor: NodeEditor<Schemes> | undefined;
-export let area: AreaPlugin<Schemes, AreaExtra> | undefined;
-export let arrange: AutoArrangePlugin<Schemes, never> | undefined;
+export let g_editor: NodeEditor<Schemes> | undefined;
+export let g_area: AreaPlugin<Schemes, AreaExtra> | undefined;
+export let g_arrange: AutoArrangePlugin<Schemes, never> | undefined;
 
 function addCustomBackground<S extends BaseSchemes, K>(
   area: AreaPlugin<S, K>
@@ -62,9 +62,11 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
     e.preventDefault();
   }, true /* use capture to fire this event before area zoom dblclick event listener */);
 
-  editor = new NodeEditor<Schemes>();
-  area = new AreaPlugin<Schemes, AreaExtra>(element);
-  arrange = new AutoArrangePlugin<Schemes>();
+  const editor = new NodeEditor<Schemes>();
+
+  g_editor = editor;
+  g_area = new AreaPlugin<Schemes, AreaExtra>(element);
+  g_arrange = new AutoArrangePlugin<Schemes>();
 
   const connection = new ConnectionPlugin<Schemes, AreaExtra>();
 
@@ -99,32 +101,48 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
 
   connection.addPreset(ConnectionPresets.classic.setup());
 
-  addCustomBackground(area);
+  addCustomBackground(g_area);
 
-  editor.use(area);
+  g_editor.use(g_area);
 
-  area.use(connection);
-  area.use(angularRender);
+  g_area.use(connection);
+  g_area.use(angularRender);
 
-  arrange.addPreset(ArrangePresets.classic.setup());
-  area.use(arrange);
+  g_arrange.addPreset(ArrangePresets.classic.setup());
+  g_area.use(g_arrange);
 
-  AreaExtensions.simpleNodesOrder(area)
-  AreaExtensions.selectableNodes(area, AreaExtensions.selector(), { accumulating: AreaExtensions.accumulateOnCtrl() });
-  AreaExtensions.snapGrid(area, { size: 10, dynamic: true });
-  AreaExtensions.showInputControl<Schemes>(area, ({ hasAnyConnection }) => {
+  AreaExtensions.simpleNodesOrder(g_area)
+  AreaExtensions.selectableNodes(g_area, AreaExtensions.selector(), { accumulating: AreaExtensions.accumulateOnCtrl() });
+  AreaExtensions.snapGrid(g_area, { size: 10, dynamic: true });
+  AreaExtensions.showInputControl<Schemes>(g_area, ({ hasAnyConnection }) => {
     return !hasAnyConnection;
   })
 
-  editor.addPipe((context: Root<Schemes>) => {
-    const { type } = context as { type: string };
+  g_editor.addPipe((context: Root<Schemes>) => {
+    const { type, data } = context as { type: string, data: { id: string, source: string, sourceOutput: string } };
     switch (type) {
+      case "connectioncreated": {
+        console.log("Connection created")
+        const node: BaseNode | undefined = editor.getNode(data.source);
+        if (node) {
+          node.addOutgoingConnection(data.sourceOutput);
+        }
+        break;
+      }
+      case "connectionremoved": {
+        console.log("Connection removed")
+        const node: BaseNode | undefined = editor.getNode(data.source)
+        if (node) {
+          node.removeOutgoingConnection(data.sourceOutput);
+        }
+        break;
+      }
       case "connectioncreate": {
 
         const { data } = context as { type: string, data: BaseConnection<BaseNode, BaseNode> };
 
-        const sourceNode: BaseNode | undefined = editor!.getNode(data.source);
-        const targetNode: BaseNode | undefined = editor!.getNode(data.target);
+        const sourceNode: BaseNode | undefined = g_editor!.getNode(data.source);
+        const targetNode: BaseNode | undefined = g_editor!.getNode(data.target);
 
         if (sourceNode && targetNode) {
 
@@ -172,12 +190,12 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
     return context;
   })
 
-  await arrange.layout();
+  await g_arrange.layout();
 
   return {
-    editor,
-    area,
-    arrange,
+    editor: g_editor,
+    area: g_area,
+    arrange: g_arrange,
     connection,
   };
 }

--- a/src/app/helper/rete/editor.ts
+++ b/src/app/helper/rete/editor.ts
@@ -122,7 +122,6 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
     const { type, data } = context as { type: string, data: { id: string, source: string, sourceOutput: string } };
     switch (type) {
       case "connectioncreated": {
-        console.log("Connection created")
         const node: BaseNode | undefined = editor.getNode(data.source);
         if (node) {
           node.addOutgoingConnection(data.sourceOutput);
@@ -130,7 +129,6 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
         break;
       }
       case "connectionremoved": {
-        console.log("Connection removed")
         const node: BaseNode | undefined = editor.getNode(data.source)
         if (node) {
           node.removeOutgoingConnection(data.sourceOutput);

--- a/src/app/schemas/graph.ts
+++ b/src/app/schemas/graph.ts
@@ -1,3 +1,5 @@
+
+
 export interface IGraph {
     description: string;
     entry: string;
@@ -5,10 +7,20 @@ export interface IGraph {
     connections: IConnection[];
     executions: IExecution[];
     registries: string[];
+    view?: IView;
 }
 
 export type IInput = unknown | string[] | number[] | boolean[] | string | number | boolean;
 export type IOutput = string | null;
+
+export interface IView {
+    transform: {
+        x: number;
+        y: number;
+        k: number;
+    }
+
+}
 
 export type ISettings = {
     folded: boolean;

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -223,8 +223,6 @@ export class GraphService {
     // and identify their associcated nodes as
     // they might need to be updated as well,
     // since a connection got taken away from them.
-
-    console.log("Delete node");
     const promisesConns = [];
 
     const associcatedNodes = new Set<string>();

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -6,9 +6,11 @@ import { NodeFactory } from './nodefactory.service';
 import { generateRandomWord } from '../helper/wordlist';
 import { IConnection, IExecution, IGraph, IInput, IOutput, INode } from '../schemas/graph';
 import { NodeEditor } from 'rete';
-import { AreaExtra, Schemes, area, editor } from '../helper/rete/editor';
-import { AreaPlugin } from 'rete-area-plugin';
+import { AreaExtra, Schemes, g_area, g_editor } from '../helper/rete/editor';
+import { AreaPlugin, NodeView } from 'rete-area-plugin';
 import { RegistryUriInfo, uriToString } from '../helper/utils';
+import { VsCodeService } from './vscode.service';
+import { environment } from 'src/environments/environment';
 
 export interface Origin {
   owner: string;
@@ -23,6 +25,7 @@ export interface Origin {
 export class GraphService {
   nf = inject(NodeFactory);
   injector = inject(Injector);
+  vscode = inject(VsCodeService);
 
   private origin$ = new BehaviorSubject<Origin | null>(null);
   originObservable$ = this.origin$.asObservable();
@@ -39,11 +42,33 @@ export class GraphService {
   private nodeCreated = new Subject<{ node: BaseNode, userCreated: boolean }>();
   onNodeCreated$ = this.nodeCreated.asObservable();
 
-  async createNode(nodeId: string, userCreated: boolean): Promise<void> {
+  private inputChangeEvent = new Subject<unknown>();
+  onInputChangeEvent$ = this.inputChangeEvent.asObservable();
+
+  constructor() {
+    if (environment.vscode) {
+      this.onInputChangeEvent$.subscribe(() => {
+        if (g_editor && g_area) {
+          const graph = this.serializeGraph(g_editor, g_area, '');
+          this.vscode.postMessage({ type: 'saveGraph', requestId: -1, data: graph });
+        }
+      });
+    }
+  }
+
+  inputChangeSuject(): Subject<unknown> {
+    return this.inputChangeEvent;
+  }
+
+  async createNode(nodeId: string, userCreated: boolean, inputs?: { [key: string]: IInput }, outputs?: { [key: string]: IOutput }): Promise<BaseNode> {
     const sanitizedNodeId = nodeId.replace(/[^a-zA-Z0-9-]/g, '-');
-    const node: BaseNode = await this.nf.createNode(`${sanitizedNodeId}-${generateRandomWord(3)}`, nodeId);
-    await editor!.addNode(node);
+    const node: BaseNode = await this.nf.createNode(`${sanitizedNodeId}-${generateRandomWord(3)}`, nodeId, this.inputChangeEvent, inputs, outputs);
+
+    await g_editor!.addNode(node);
+
     this.nodeCreated.next({ node: node, userCreated });
+
+    return node
   }
 
   isReadOnly(): boolean {
@@ -107,7 +132,7 @@ export class GraphService {
         }
       }
 
-      const view = area.nodeViews.get(node.id);
+      const view: NodeView | undefined = area.nodeViews.get(node.id);
       nodes.push({
         id: node.id,
         type: node.getType(),
@@ -163,6 +188,9 @@ export class GraphService {
       nodes: nodes,
       registries: [...gs.getRegistries()],
       description,
+      view: {
+        transform: area.area.transform
+      },
     };
 
     return dump(graph, {
@@ -196,13 +224,14 @@ export class GraphService {
     // they might need to be updated as well,
     // since a connection got taken away from them.
 
+    console.log("Delete node");
     const promisesConns = [];
 
     const associcatedNodes = new Set<string>();
 
-    for (const conn of editor!.getConnections()) {
+    for (const conn of g_editor!.getConnections()) {
       if (conn.source === nodeId || conn.target === nodeId) {
-        promisesConns.push(editor!.removeConnection(conn.id));
+        promisesConns.push(g_editor!.removeConnection(conn.id));
         if (conn.source === nodeId) {
           associcatedNodes.add(conn.target);
         } else {
@@ -211,13 +240,13 @@ export class GraphService {
       }
     }
 
-    await editor!.removeNode(nodeId);
+    await g_editor!.removeNode(nodeId);
     await Promise.all(promisesConns);
 
     const promisesNodes = [];
 
     for (const nodeId of associcatedNodes) {
-      promisesNodes.push(area!.update("node", nodeId));
+      promisesNodes.push(g_area!.update("node", nodeId));
     }
 
     await Promise.all(promisesNodes);

--- a/src/app/services/nodefactory.service.ts
+++ b/src/app/services/nodefactory.service.ts
@@ -3,14 +3,17 @@ import { BaseNode } from "../helper/rete/basenode";
 import { IInputDefinition, INodeTypeDefinitionFull, IOutputDefinition } from "../helper/rete/interfaces/nodes";
 import { Registry } from "./registry.service";
 import { IInput, IOutput } from "../schemas/graph";
+import { VsCodeService } from "./vscode.service";
+import { Subject } from "rxjs";
 
 @Injectable({
     providedIn: 'root'
 })
 export class NodeFactory {
     injector = inject(Injector);
+    vscode = inject(VsCodeService);
 
-    async createNode(id: string, type: string, inputs?: { [key: string]: IInput }, outputs?: { [key: string]: IOutput }): Promise<BaseNode> {
+    async createNode(id: string, type: string, inputChangeEvent: Subject<unknown>, inputs?: { [key: string]: IInput }, outputs?: { [key: string]: IOutput }): Promise<BaseNode> {
 
         const nr = this.injector.get(Registry);
 
@@ -67,13 +70,13 @@ export class NodeFactory {
 
             for (const [inputId, inputDef] of inputDefs) {
 
-                const input = n.addInput2(inputId, inputDef, false);
+                const input = n.addInput2(inputId, inputDef, inputChangeEvent, false);
 
                 // Regard the group initial value only for new nodes
                 if (inputs === undefined) {
                     if (inputDef.group_initial && typeof inputDef.group_initial === 'number') {
                         for (let i = 0; i < inputDef.group_initial; ++i) {
-                            await n.appendInputValue(input);
+                            await n.appendInputValue(input, inputChangeEvent);
                         }
                     }
                 }

--- a/src/app/services/vscode.service.ts
+++ b/src/app/services/vscode.service.ts
@@ -22,6 +22,7 @@ export type VsCodeMessage = {
 })
 export class VsCodeService {
     _vsCode: VsCodeApi | undefined;
+
     _requestId = 0;
     _callbacks = new Map<number, (data: unknown) => void>();
 
@@ -50,10 +51,6 @@ export class VsCodeService {
                 }
             }
         });
-    }
-
-    isVsCode(): boolean {
-        return !!this._vsCode;
     }
 
     postMessageWithResponse<R = unknown>(type: string, data: R): Promise<unknown> {


### PR DESCRIPTION
As described in #1, the canvas was empty after certain user interactions, like switching to another tab and back in VS Code. This fix serializes the graph at certain UI events (like modifying the value of an input, moving a node around, or even shifting the view in the graph canvas). See the events below:

https://github.com/actionforge/graph-editor/blob/b4d3871d817a26b40a0a5f83ee5ac927196ee99f/src/app/components/graph-editor/graph-editor.component.ts#L417-L421

https://github.com/actionforge/graph-editor/blob/b4d3871d817a26b40a0a5f83ee5ac927196ee99f/src/app/components/graph-editor/graph-editor.component.ts#L402-L403

Also the "camera" position of the graph canvas is now stored in the graph yaml in order to restore the same state.