### PR TITLE
Change readable flag to permission to avoid flashing "read-only" banner

### DIFF
--- a/src/app/components/basecontrol/basecontrol.component.html
+++ b/src/app/components/basecontrol/basecontrol.component.html
@@ -41,12 +41,12 @@
 
   <ng-container *ngIf="!data.multiline; else stringMulti">
     <input type="text" class="w-full cid-input" (keydown)="onChange($event, index)" [class.cid-required]="isEmpty()"
-      autocomplete="off" [placeholder]="data.hint || ''" [value]="value" [readonly]="isReadOnly()" />
+      autocomplete="off" [placeholder]="data.hint || ''" [value]="value" [readonly]="!getPermission()" />
   </ng-container>
 
   <ng-template #stringMulti>
     <vscode-text-area #input class="w-full cid-input" (blur)="onChange($event)" [class.cid-required]="isEmpty()"
-      [readonly]="isReadOnly()" [value]="value"></vscode-text-area>
+      [readonly]="!getPermission()" [value]="value"></vscode-text-area>
   </ng-template>
 
 </ng-template>
@@ -57,7 +57,7 @@
 </ng-template>
 
 <ng-template #number let-value="value">
-  <input #input type="number" (keydown)="onChange($event)" [value]="value" [readonly]="isReadOnly()" [title]="value"
+  <input #input type="number" (keydown)="onChange($event)" [value]="value" [readonly]="!getPermission()" [title]="value"
     [step]="data.step " placeholder=" " />
 </ng-template>
 

--- a/src/app/components/basecontrol/basecontrol.component.ts
+++ b/src/app/components/basecontrol/basecontrol.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Component, ElementRef, HostListener, Input, OnChanges, SimpleChanges, ViewChild, inject } from '@angular/core';
 import { BaseControl, BaseControlType } from 'src/app/helper/rete/basecontrol';
-import { GraphService } from 'src/app/services/graph.service';
+import { GraphService, Writable as Permission } from 'src/app/services/graph.service';
 
 @Component({
   selector: 'app-basecontrol',
@@ -21,8 +21,8 @@ export class BaseControlComponent implements OnChanges {
     this.cdr.detach();
   }
 
-  isReadOnly(): boolean {
-    return this.gs.isReadOnly();
+  getPermission(): Permission {
+    return this.gs.getPermission();
   }
 
   isEmpty(): boolean {

--- a/src/app/components/graph-editor/graph-editor.component.html
+++ b/src/app/components/graph-editor/graph-editor.component.html
@@ -1,7 +1,7 @@
 <!-- Flex box to fill the remaining vertical space -->
 <div class="flex flex-row h-full">
 
-   <div *ngIf="(isReadOnly() | async) === true"
+   <div *ngIf="(getPermission() | async) === Writable.ReadOnly"
       class="absolute flex items-center justify-center w-40 h-8 right-0 dark:bg-gray-800 transform rotate-45 translate-y-6 translate-x-12">
       Read only
    </div>
@@ -14,7 +14,7 @@
    </div>
 
    <!-- Node Toolbar-->
-   <div class="relative" *ngIf="(isReadOnly() | async) === false">
+   <div class="relative" *ngIf="(getPermission() | async) === Writable.Writable">
       <div
          class="absolute z-[500] left-4 top-4 flex flex-col text-gray-700 dark:text-white fill-gray-700 dark:fill-white">
 
@@ -38,7 +38,7 @@
    </div>
 
    <!-- Sidebar -->
-   <ng-container *ngIf="(isReadOnly() | async) === false">
+   <ng-container *ngIf="(getPermission() | async) === Writable.Writable">
       <app-sidebar></app-sidebar>
    </ng-container>
 

--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -6,7 +6,7 @@ import { BaseNode } from 'src/app/helper/rete/basenode';
 import { BaseSocket } from 'src/app/helper/rete/basesocket';
 import { Schemes, g_area, g_arrange, createEditor, g_editor, readonly, AreaExtra } from 'src/app/helper/rete/editor';
 import { IGraph, INode } from 'src/app/schemas/graph';
-import { GraphService, Origin } from 'src/app/services/graph.service';
+import { GraphService, Origin, Writable } from 'src/app/services/graph.service';
 import { NodeFactory } from 'src/app/services/nodefactory.service';
 import { Registry } from 'src/app/services/registry.service';
 import { octKey, octTerminal } from '@ng-icons/octicons';
@@ -52,6 +52,8 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   cdr = inject(ChangeDetectorRef);
 
   @ViewChild('rete') container!: ElementRef<HTMLElement>;
+
+  Writable = Writable;
 
   nodeButtonSeries = [
     [
@@ -178,8 +180,8 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
     }
   });
 
-  isReadOnly(): Observable<boolean> {
-    return this.gs.readOnlyObservable$;
+  getPermission(): Observable<Writable> {
+    return this.gs.permissionObservable$;
   }
 
   isVsCode(): boolean {
@@ -199,7 +201,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   async openGraph(uri: string, graph: string, transform: Transform | null): Promise<void> {
-    await this.gs.loadGraph(graph, environment.web || uri.startsWith("git:"), async (g: IGraph) => {
+    await this.gs.loadGraph(graph, environment.vscode && !uri.startsWith("git:"), async (g: IGraph) => {
       await this.loadGraphToEditor(g, transform);
     });
 

--- a/src/app/components/rete/node/basenode.component.html
+++ b/src/app/components/rete/node/basenode.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!isReadOnly()" [class.opacity-100]="mouseover" class="flex items-center pointer-events-none justify-between gap-x-2 absolute z-[100] px-2 -top-8 h-8 w-full text-gray-700 dark:text-gray-300 
+<div *ngIf="getPermission()" [class.opacity-100]="mouseover" class="flex items-center pointer-events-none justify-between gap-x-2 absolute z-[100] px-2 -top-8 h-8 w-full text-gray-700 dark:text-gray-300 
   opacity-0 transition duration-500">
   <!-- Fold Button-->
   <ng-icon [name]="getFoldIcon()" size="18" [matTooltip]="getFoldTooltip()"
@@ -40,7 +40,7 @@
 
 <!-- Node Body -->
 <div class="cid-body w-full flex flex-col bg-gray-200 dark:bg-slate-700 rounded-b-lg"
-  [class.pointer-events-none]="isReadOnly()" [style.background]="getBodyBackground() | safe:'style'"
+  [class.pointer-events-none]="!getPermission()" [style.background]="getBodyBackground() | safe:'style'"
   [class.rounded-t-lg]="isCompact()">
 
   <div [ngClass]="isCompact() ? 'flex flex-row justify-center items-center' : 'flex flex-col'">

--- a/src/app/components/rete/node/basenode.component.ts
+++ b/src/app/components/rete/node/basenode.component.ts
@@ -13,7 +13,7 @@ import { BaseInput } from "src/app/helper/rete/baseinput";
 import { BaseNode } from "src/app/helper/rete/basenode";
 import { BaseOutput } from "src/app/helper/rete/baseoutput";
 import { g_area, g_editor } from "src/app/helper/rete/editor";
-import { GraphService } from "src/app/services/graph.service";
+import { GraphService, Writable } from "src/app/services/graph.service";
 import { NodeFactory } from "src/app/services/nodefactory.service";
 import { Registry } from "src/app/services/registry.service";
 
@@ -199,8 +199,8 @@ export class BaseNodeComponent implements OnChanges {
     return this.data.getDefinition().registry === "github.com";
   }
 
-  isReadOnly(): boolean {
-    return this.gs.isReadOnly();
+  getPermission(): Writable {
+    return this.gs.getPermission();
   }
 
   getIcon(): string | null {
@@ -216,11 +216,11 @@ export class BaseNodeComponent implements OnChanges {
   }
 
   showOutputGroupButtons(port: BaseOutput): boolean {
-    return !this.gs.isReadOnly() && Boolean(port.def.group);
+    return this.gs.getPermission() === Writable.Writable && Boolean(port.def.group);
   }
 
   showInputGroupButtons(port: BaseInput): boolean {
-    return !this.gs.isReadOnly() && (Boolean(port.def.group) || (port.isArray() && Boolean(port.control && port.showControl)));
+    return this.gs.getPermission() === Writable.Writable && (Boolean(port.def.group) || (port.isArray() && Boolean(port.control && port.showControl)));
   }
 
   showInputControl(port: BaseInput): boolean {


### PR DESCRIPTION
This PR fixes an issue where the read-only banner flashes during start, although the graph is writable.

<img width="155" src="https://github.com/actionforge/graph-editor/assets/12844423/cfc3c861-15ea-4815-9f27-b67b8a45fa7d">

This happens due to a binary read/write flag. To avoid inverting the flashing by showing write buttons, this PR introduces a trinary flag (read, write, unknown) where the latter is the default