### PR TITLE
Filter css attribute requires read-only banner placed after rete div

### DIFF
--- a/src/app/components/graph-editor/graph-editor.component.html
+++ b/src/app/components/graph-editor/graph-editor.component.html
@@ -1,11 +1,6 @@
 <!-- Flex box to fill the remaining vertical space -->
 <div class="flex flex-row h-full">
 
-   <div *ngIf="(getPermission() | async) === Permission.ReadOnly"
-      class="absolute flex items-center justify-center w-40 h-8 right-0 dark:bg-gray-800 transform rotate-45 translate-y-6 translate-x-12">
-      Read only
-   </div>
-
    <div class="relative" *ngIf="isWeb()">
       <div *ngIf="(getOrigin() | async) as o"
          class="absolute z-[500] text-xl left-4 top-4 flex flex-col fill-gray-700 dark:fill-white whitespace-nowrap">
@@ -35,6 +30,11 @@
    <!-- Graph Canvas -->
    <div class="cid-rete-background">
       <div class="cid-rete" #rete [class.readonly]="(getPermission() | async) === Permission.ReadOnly"> </div>
+   </div>
+
+   <div *ngIf="(getPermission() | async) === Permission.ReadOnly"
+      class="absolute flex items-center justify-center w-40 h-8 right-0 dark:bg-gray-800 transform rotate-45 translate-y-6 translate-x-12">
+      Read only
    </div>
 
    <!-- Sidebar -->


### PR DESCRIPTION
As title says, the introduction of the filter attribute on the css div requires the read-only banner being placed after the rete div.

https://github.com/actionforge/graph-editor/blob/f8b94523440d8b727c7581ffa83072610be4a5ed/src/app/components/graph-editor/graph-editor.component.scss#L20-L24