### PR TITLE
Graph must be non-empty otherwise empty graphs are not displayed

### DIFF
--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -66,7 +66,7 @@ export class GraphService {
 
   async loadGraph(graph: string, writable: boolean, cb: LoadingGraphFunction): Promise<void> {
 
-    if (this.lastGraph === graph) {
+    if (graph !== "" && this.lastGraph === graph) {
       return;
     }
 


### PR DESCRIPTION
Fixes #11 