### PR TITLE
Add commands to fit all nodes to canvas and arrange nodes

### DIFF
--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -24,8 +24,9 @@ import { featherSearch } from '@ng-icons/feather-icons';
 import { SocketData } from 'rete-connection-plugin';
 import { BaseInput } from 'src/app/helper/rete/baseinput';
 import { BaseOutput } from 'src/app/helper/rete/baseoutput';
-import { Area2D } from 'rete-area-plugin';
+import { Area2D, AreaExtensions } from 'rete-area-plugin';
 import { Transform } from 'rete-area-plugin/_types/area';
+
 import { dump } from 'js-yaml';
 
 import debounce from 'lodash.debounce';
@@ -170,15 +171,26 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   messageSubscription = this.vscode.messageObservable$.subscribe(async (e: VsCodeMessage) => {
     const { type, data } = e.data;
     switch (type) {
+      case 'arrangeNodes': {
+        await this.arrangeNodes();
+        break;
+      }
+      case 'fitToCanvas': {
+        await this.fitToCanvas();
+        break;
+      }
       case 'setFileData': {
         const d = data as {
           data: string;
           uri: string;
-          transform: Transform
+          transform: Transform | null
         }
 
         try {
-          await this.debounceOpenGraph(d.uri, d.data, d.transform)
+          await this.debounceOpenGraph(d.uri, d.data, d.transform);
+          if (!d.transform) {
+            await this.fitToCanvas();
+          }
         } catch (error) {
           console.error(error);
           void this.ns.showNotification(NotificationType.Error, getErrorMessage(error));
@@ -209,14 +221,20 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
   }
 
   async openGraph(uri: string, graph: string, transform: Transform | null): Promise<void> {
+    if (!g_editor) {
+      throw new Error('editor not initialized');
+    } else if (!g_area) {
+      throw new Error('area not initialized');
+    }
+
     await this.gs.loadGraph(graph, environment.vscode && !uri.startsWith("git:"), async (g: IGraph) => {
       await this.loadGraphToEditor(g, transform);
     });
 
     const promises = [];
 
-    for (const node of g_editor!.getNodes()) {
-      promises.push(g_area!.update("node", node.id));
+    for (const node of g_editor.getNodes()) {
+      promises.push(g_area.update("node", node.id));
     }
 
     await Promise.all(promises);
@@ -445,10 +463,28 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
         provider: 'github', owner, repo, ref, path,
       });
       await this.openGraph(location.pathname, dump(graph), null);
+      await this.fitToCanvas();
     }
   }
 
   async arrangeNodes(): Promise<void> {
-    await g_arrange!.layout();
+    if (!g_arrange) {
+      throw new Error('arrange not initialized');
+    }
+    await g_arrange.layout();
+  }
+
+  async fitToCanvas(): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        if (!g_editor) {
+          throw new Error('editor not initialized');
+        } else if (!g_area) {
+          throw new Error('area not initialized');
+        }
+        void AreaExtensions.zoomAt(g_area, g_editor.getNodes(), { scale: 0.75 })
+          .then(resolve)
+      }, 0);
+    })
   }
 }

--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -188,9 +188,6 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
 
         try {
           await this.debounceOpenGraph(d.uri, d.data, d.transform);
-          if (!d.transform) {
-            await this.fitToCanvas();
-          }
         } catch (error) {
           console.error(error);
           void this.ns.showNotification(NotificationType.Error, getErrorMessage(error));
@@ -238,6 +235,10 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
     }
 
     await Promise.all(promises);
+
+    if (!transform) {
+      await this.fitToCanvas();
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/helper/rete/basenode.ts
+++ b/src/app/helper/rete/basenode.ts
@@ -21,8 +21,12 @@ const portTypeToControlTypeMapping = new Map<string, BaseControlType>([
 
 export class BaseNode extends ClassicPreset.Node {
 
-  width = 64;
-  height = 64;
+  get width(): number {
+    return document.querySelector(`node-${this.id}`)?.clientWidth ?? 0;
+  }
+  get height(): number {
+    return document.querySelector(`node-${this.id}`)?.clientHeight ?? 0;
+  }
 
   // Different from ClassicPreset.Node.
   // Similar to github/sebastianrath/node-js-examples/fibnode@v4
@@ -88,14 +92,6 @@ export class BaseNode extends ClassicPreset.Node {
 
   getSettings(): ISettings {
     return this.settings;
-  }
-
-  setWidth(width: number): void {
-    this.width = width;
-  }
-
-  setHeight(height: number): void {
-    this.height = height;
   }
 
   setInputValue(portId: string, portValue: unknown): void {

--- a/src/app/helper/rete/editor.ts
+++ b/src/app/helper/rete/editor.ts
@@ -188,8 +188,6 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
     return context;
   })
 
-  await g_arrange.layout();
-
   return {
     editor: g_editor,
     area: g_area,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     ],
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "strictNullChecks": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
@@ -33,7 +34,7 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
   },
   "exclude": [
     "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,16 +7,27 @@
       "node"
     ],
     "forceConsistentCasingInFileNames": true,
+    // strict
+    "alwaysStrict": true,
     "strict": true,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    // no
     "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
     "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noFallthroughCasesInSwitch": true,
+    // use
+    "useUnknownInCatchVariables": true,
+    // allow
+    "allowSyntheticDefaultImports": true,
     "inlineSources": true,
     "inlineSourceMap": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true,
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
@@ -31,13 +42,15 @@
     ],
   },
   "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
+    "strictTemplates": true,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true,
+    "enableI18nLegacyMessageIdFormat": false,
   },
   "exclude": [
     "node_modules",
-    ".eslintrc.json"
+    ".eslintrc.json",
+    "src/environments/environment.vscode.ts",
+    "src/environments/environment.web.ts"
   ],
 }


### PR DESCRIPTION
This PR adds two commands, to fit all nodes to canvas (screen), and to arrange all nodes. These commands are currently only invokable by VS Code. If these commands need to be available through the UI, the buttons need to be still added.