### PR TITLE
Add linter to gh actions workflow

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,12 @@
   "root": true,
   "parser": "@typescript-eslint/parser",
   "ignorePatterns": [
-    "projects/**/*"
+    "src/environments/environment.dev.ts",
+    "src/environments/environment.web.ts"
   ],
   "parserOptions": {
     "project": [
-      "tsconfig.(app|spec).json"
+      "tsconfig.(app|spec|vscode).json"
     ]
   },
   "overrides": [

--- a/.github/workflows/graphs/workflow.yml
+++ b/.github/workflows/graphs/workflow.yml
@@ -1,0 +1,58 @@
+entry: gh-start
+executions:
+  - src:
+      node: gh-start
+      port: exec-on-push
+    dst:
+      node: github-com-actions-checkout-lemon-pink-apple
+      port: exec
+  - src:
+      node: github-com-actions-checkout-lemon-pink-apple
+      port: exec
+    dst:
+      node: github-com-actions-setup-node-blue-panda-gray
+      port: exec
+  - src:
+      node: github-com-actions-setup-node-blue-panda-gray
+      port: exec
+    dst:
+      node: run-v1-parrot-yellow-parrot
+      port: exec
+connections: []
+nodes:
+  - id: gh-start
+    type: gh-start@v1
+    position:
+      x: 100
+      y: 100
+    settings:
+      folded: false
+  - id: run-v1-parrot-yellow-parrot
+    type: run@v1
+    position:
+      x: 1750
+      y: 440
+    inputs:
+      script: |-
+        npm install
+        npm run lint
+    settings:
+      folded: false
+  - id: github-com-actions-checkout-lemon-pink-apple
+    type: github.com/actions/checkout
+    position:
+      x: 550
+      y: 310
+    settings:
+      folded: false
+  - id: github-com-actions-setup-node-blue-panda-gray
+    type: github.com/actions/setup-node
+    position:
+      x: 1170
+      y: 390
+    inputs:
+      node-version: v20.8.0
+    settings:
+      folded: false
+registries: []
+description: ''

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,11 @@
+on: [push]
+
+jobs:
+    build-and-publish:
+      runs-on: ubuntu-latest
+      name: My workflow
+      steps:
+        - name: Execute Action Graph
+          uses: actionforge/action@v0.4.35
+          with:
+            graph_file: workflow.yml


### PR DESCRIPTION
This PR executes `npm lint` as a gh actions workflow step.