### PR TITLE
Add explicit-function-return-type and no-shadow rule for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,7 +46,17 @@
             "caughtErrorsIgnorePattern": "^_"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "error"
+        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/explicit-function-return-type": [
+          "error",
+          {
+            "allowedNames": [
+              "ignoredFunctionName",
+              "ignoredMethodName"
+            ]
+          }
+        ],
+        "@typescript-eslint/no-shadow": "error"
       }
     },
     {

--- a/src/app/components/basecontrol/basecontrol.component.ts
+++ b/src/app/components/basecontrol/basecontrol.component.ts
@@ -49,7 +49,7 @@ export class BaseControlComponent implements OnChanges {
   @HostListener("wheel", ["$event"])
   @HostListener('dblclick', ["$event"])
   @HostListener('pointerdown', ["$event"])
-  mouseenter(event: MouseEvent) {
+  mouseEnter(event: MouseEvent): void {
 
     // Stop all events from bubbling up as the
     // input field took all the events
@@ -80,7 +80,7 @@ export class BaseControlComponent implements OnChanges {
     }
   }
 
-  onChange(e: Event | KeyboardEvent | FocusEvent, index?: number) {
+  onChange(e: Event | KeyboardEvent | FocusEvent, index?: number): void {
     // Event can be KeyboardEvent or MouseEvent
 
     const target = e.target as HTMLInputElement;

--- a/src/app/components/graph-editor/graph-editor.component.ts
+++ b/src/app/components/graph-editor/graph-editor.component.ts
@@ -324,7 +324,7 @@ export class GraphEditorComponent implements AfterViewInit, OnDestroy {
     await Promise.all(createConnections);
   }
 
-  async ngAfterViewInit() {
+  async ngAfterViewInit(): Promise<void> {
 
     const { editor, area, connection } = await createEditor(this.container.nativeElement, this.injector);
 

--- a/src/app/components/rete/node/basenode.component.ts
+++ b/src/app/components/rete/node/basenode.component.ts
@@ -141,7 +141,7 @@ export class BaseNodeComponent implements OnChanges {
   }
 
   @HostListener('mouseover')
-  onMouseOver() {
+  onMouseOver(): void {
     if (!this.mouseover) {
       this.mouseover = true;
       this.cdr.detectChanges();
@@ -149,7 +149,7 @@ export class BaseNodeComponent implements OnChanges {
   }
 
   @HostListener('mouseout')
-  onMouseOut() {
+  onMouseOut(): void {
     if (this.mouseover) {
       this.mouseover = false;
       this.cdr.detectChanges();

--- a/src/app/directives/vscode-text-area.ts
+++ b/src/app/directives/vscode-text-area.ts
@@ -33,14 +33,14 @@ export class VscodeTextAreaValueAccessorDirective implements ControlValueAccesso
     }
 
     @HostListener('input', ['$event.target.value'])
-    onInput(value: unknown) {
+    onInput(value: unknown): void {
         if (this.onChange) {
             this.onChange(value);
         }
     }
 
     @HostListener('blur')
-    onBlur() {
+    onBlur(): void {
         if (this.onTouched) {
             this.onTouched();
         }

--- a/src/app/helper/rete/basecontrol.ts
+++ b/src/app/helper/rete/basecontrol.ts
@@ -67,7 +67,7 @@ export class BaseControl<T extends BaseControlType | unknown, N =
         return this.opts.getValue();
     }
 
-    setValue(value?: N) {
+    setValue(value?: N): void {
         this.opts.setValue(value)
     }
 }

--- a/src/app/helper/rete/basenode.ts
+++ b/src/app/helper/rete/basenode.ts
@@ -155,7 +155,7 @@ export class BaseNode extends ClassicPreset.Node {
           group: def.group,
           options: def.options,
           multiline: def.multiline,
-          setValue: (value: unknown) => {
+          setValue: (value: unknown): void => {
             this.setInputValue(inputName, value);
 
             inputChangeEvent.next(value);

--- a/src/app/helper/rete/editor.ts
+++ b/src/app/helper/rete/editor.ts
@@ -40,7 +40,7 @@ export let g_arrange: AutoArrangePlugin<Schemes, never> | undefined;
 
 function addCustomBackground<S extends BaseSchemes, K>(
   area: AreaPlugin<S, K>
-) {
+): void {
   const background = document.createElement("div");
 
   background.classList.add("bg-red-50");
@@ -119,9 +119,11 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
   })
 
   g_editor.addPipe((context: Root<Schemes>) => {
-    const { type, data } = context as { type: string, data: { id: string, source: string, sourceOutput: string } };
+    const { type } = context as { type: string };
     switch (type) {
       case "connectioncreated": {
+        const { data } = context as { data: { id: string, source: string, sourceOutput: string } };
+
         const node: BaseNode | undefined = editor.getNode(data.source);
         if (node) {
           node.addOutgoingConnection(data.sourceOutput);
@@ -129,6 +131,8 @@ export async function createEditor(element: HTMLElement, injector: Injector): Pr
         break;
       }
       case "connectionremoved": {
+        const { data } = context as { data: { id: string, source: string, sourceOutput: string } };
+
         const node: BaseNode | undefined = editor.getNode(data.source)
         if (node) {
           node.removeOutgoingConnection(data.sourceOutput);

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -282,8 +282,8 @@ export class GraphService {
 
     const promisesNodes = [];
 
-    for (const nodeId of associcatedNodes) {
-      promisesNodes.push(g_area!.update("node", nodeId));
+    for (const subNodeId of associcatedNodes) {
+      promisesNodes.push(g_area!.update("node", subNodeId));
     }
 
     await Promise.all(promisesNodes);

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -26,7 +26,7 @@ export class NotificationService {
 
   showNotification(type: NotificationType, message: string, opts?: {
     timeout?: number;
-  }) {
+  }): void {
     const notification: INotification = { type, message };
 
     // Remove notifications after n-seconds
@@ -39,7 +39,7 @@ export class NotificationService {
     this.notificationSubject.next([...this.notificationQueue]); // Emit a new copy of the queue
   }
 
-  clearNotification(notification: INotification) {
+  clearNotification(notification: INotification): void {
     const index = this.notificationQueue.indexOf(notification);
     if (index !== -1) {
       this.notificationQueue.splice(index, 1);


### PR DESCRIPTION
This PR adds two additional rules to `eslint` and fixes the corresponding warnings:

```json
"@typescript-eslint/no-floating-promises": "error",
"@typescript-eslint/explicit-function-return-type": [...],
```