### PR TITLE
Creating a new action graph causes exception bug

### DIFF
--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -11,7 +11,6 @@ import { AreaPlugin, NodeView } from 'rete-area-plugin';
 import { RegistryUriInfo, uriToString } from '../helper/utils';
 import { VsCodeService } from './vscode.service';
 import { Registry } from './registry.service';
-import { INodeTypeDefinitionBasic } from '../helper/rete/interfaces/nodes';
 
 import AsyncLock from 'async-lock';
 
@@ -80,15 +79,15 @@ export class GraphService {
       this.lastGraph = '';
 
       // Assume this is a new document if graph is empty and prefill with a trigger node
-      if (!graph || Object.keys(graph).length === 0) {
+      if (graph || Object.keys(graph).length === 0) {
         await nr.loadBasicNodeTypeDefinitions(new Set(["gh-start@v1"]));
 
-        const nodeGhStart = (nr.getBasicNodeTypeDefinitionsSync() as Map<string, INodeTypeDefinitionBasic>).get("gh-start@v1");
+        const nodeGhStart = nr.findBasicNodeTypeDefinitionsSync((nodeId: string) => nodeId === "gh-start@v1");
         if (!nodeGhStart) {
           throw new Error("gh-start@v1 not found");
         }
 
-        const nodeGhCheckout = (nr.getBasicNodeTypeDefinitionsSync() as Map<string, INodeTypeDefinitionBasic>).get("github.com/actions/checkout");
+        const nodeGhCheckout = nr.findBasicNodeTypeDefinitionsSync((nodeId: string) => nodeId.startsWith("github.com/actions/checkout"));
         if (!nodeGhCheckout) {
           throw new Error("github.com/actions/checkout not found");
         }

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -88,7 +88,7 @@ export class GraphService {
           throw new Error("gh-start@v1 not found");
         }
 
-        const nodeGhCheckout = (nr.getBasicNodeTypeDefinitionsSync() as Map<string, INodeTypeDefinitionBasic>).get("github.com/actions/checkout@v4");
+        const nodeGhCheckout = (nr.getBasicNodeTypeDefinitionsSync() as Map<string, INodeTypeDefinitionBasic>).get("github.com/actions/checkout");
         if (!nodeGhCheckout) {
           throw new Error("github.com/actions/checkout not found");
         }

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -25,17 +25,16 @@ export class Registry {
         try {
             // add some default registry urls
             const registryUriCopy = new Set<string>(registryUrl);
-            registryUriCopy.add("github.com/actions/checkout");
             registryUriCopy.add("github.com/actions/cache");
-            registryUriCopy.add("github.com/actions/publish-action");
-            registryUriCopy.add("github.com/actions/upload-artifact");
+            registryUriCopy.add("github.com/actions/checkout");
             registryUriCopy.add("github.com/actions/create-release");
-            registryUriCopy.add("github.com/actions/upload-release-asset");
+            registryUriCopy.add("github.com/actions/publish-action");
             registryUriCopy.add("github.com/actions/setup-dotnet");
-            registryUriCopy.add("github.com/actions/setup-node");
-            registryUriCopy.add("github.com/actions/setup-java");
             registryUriCopy.add("github.com/actions/setup-go");
+            registryUriCopy.add("github.com/actions/setup-java");
+            registryUriCopy.add("github.com/actions/setup-node");
             registryUriCopy.add("github.com/actions/setup-python");
+            registryUriCopy.add("github.com/actions/upload-artifact");
 
             const nodeDefs = await this.yamlService.httpPost<INodeTypeDefinitionBasic[]>(`${environment.registryUrl}/api/v1/registry/nodedefs/basic`, {
                 registry_uris: [...registryUriCopy]

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -116,8 +116,18 @@ export class Registry {
         return this.basicNodeTypeObservable$;
     }
 
-    getBasicNodeTypeDefinitionsSync(): Map<string, INodeTypeDefinitionBasic> | 'loading' {
-        return this.partDefs.value;
+    findBasicNodeTypeDefinitionsSync(matchFn: (nodeId: string) => boolean): INodeTypeDefinitionBasic | null {
+        if (this.partDefs.value === 'loading') {
+            throw new Error('Basic node type definitions are still loading');
+        }
+
+        for (const [k, v] of this.partDefs.value) {
+            if (matchFn(k)) {
+                return v;
+            }
+        }
+
+        return null;
     }
 
     getFullNodeTypeDefinitions(): Map<string, INodeTypeDefinitionFull> {


### PR DESCRIPTION
This PR fixes an issue where the node registry expected a full string match on the requested action name. The new API gateway automatically attaches the latest release version to the node id, and therefore the strings don't match anymore. E.: `github.com/actions/checkout !== github.com/actions/checkout@v4`. This fix now uses `startsWith` for new action graphs.

Also sort the default actions and remove `upload-release-asset` since it is deprecated.