### PR TITLE
Fix regex to parse refs of user provided node uris

### DIFF
--- a/src/app/helper/utils.ts
+++ b/src/app/helper/utils.ts
@@ -67,8 +67,7 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
         uri.startsWith("www.") ||
         uri.startsWith("github.com")
     ) {
-        // TODO: (Seb) User might enter www.github.com or github.com without http/https.
-        const matches = uri.match(/^((http:\/\/|https:\/\/)?)((www.)?github.com)(\/marketplace)?\/(.+?)\/(.+?)$/);
+        const matches = uri.match(/^((http:\/\/|https:\/\/)?)((www.)?github.com)(\/marketplace)?\/(.+?)\/(.+?)(@([a-zA-Z][a-zA-Z0-9._/-]*)?)$/);
         if (!matches) {
             throw new Error("invalid node type id");
         }
@@ -112,7 +111,7 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
 
     // As a fallback, if YAML failed, try to parse the node type uri
     // if it fits the format of[registry:]name/foo[@ref]
-    const matches = uri.match(/(([-.\w]+)\/)?([-\w]+)\/([-\w]+)((@([-.\w]+))?)/);
+    const matches = uri.match(/^(([-.\w]+)\/)?([-\w]+)\/([-\w]+)((@([-.\w]+))?)$/);
     if (!matches) {
         throw new Error("invalid node type id");
     }

--- a/src/app/helper/utils.ts
+++ b/src/app/helper/utils.ts
@@ -73,11 +73,10 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
         }
 
         return {
-            // http/https is matches[1] and skipped
             registry: matches[3].toLowerCase(),
             owner: matches[6].toLowerCase(),
             regname: matches[7].toLowerCase(),
-            ref: "", // TODO: (Seb) Check if the url contains a ref
+            ref: matches[9],
         };
     }
 


### PR DESCRIPTION
This PR fixes an issue where the ref of a pasted GitHub action wasn't properly parsed.