### PR TITLE
Feature/resolve

### DIFF
--- a/src/app/components/graph-editor/graph-editor.component.html
+++ b/src/app/components/graph-editor/graph-editor.component.html
@@ -27,14 +27,14 @@
       </div>
    </div>
 
-   <!-- Graph Canvas -->
-   <div class="cid-rete-background" [class.readonly]="isVsCode() && (getPermission() | async) === Permission.ReadOnly">
-      <div class="cid-rete" #rete> </div>
-   </div>
-
    <div *ngIf="(getPermission() | async) === Permission.ReadOnly"
       class="absolute flex items-center justify-center w-40 h-8 right-0 dark:bg-gray-800 transform rotate-45 translate-y-6 translate-x-12">
       Read only
+   </div>
+
+   <!-- Graph Canvas -->
+   <div class="cid-rete-background" [class.readonly]="isVsCode() && (getPermission() | async) === Permission.ReadOnly">
+      <div class="cid-rete" #rete> </div>
    </div>
 
    <!-- Sidebar -->

--- a/src/app/components/graph-editor/graph-editor.component.scss
+++ b/src/app/components/graph-editor/graph-editor.component.scss
@@ -15,10 +15,10 @@
 
   &.readonly {
     content: "";
-    padding: 25px;
+    padding: 5px;
     background: repeating-linear-gradient(45deg,
-        #606dbc,
-        #606dbc 10px,
+        var(--vscode-editor-background),
+        var(--vscode-editor-background) 10px,
         #465298 10px,
         #465298 20px);
   }

--- a/src/app/components/rete/node/basenode.component.html
+++ b/src/app/components/rete/node/basenode.component.html
@@ -1,13 +1,13 @@
 <div *ngIf="getPermission() === Permission.Writable" [class.opacity-100]="mouseover" class="flex items-center pointer-events-none justify-between gap-x-2 absolute z-[100] px-2 -top-8 h-8 w-full text-gray-700 dark:text-gray-300 
   opacity-0 transition duration-500">
   <!-- Fold Button-->
-  <ng-icon [name]="getFoldIcon()" size="18" [matTooltip]="getFoldTooltip()"
-    (pointerdown)="onShowHideConnectedPorts($event)" matTooltipPosition="above"
+  <ng-icon [name]="getFoldIcon()" size="18" [title]="getFoldTooltip()" (pointerdown)="onShowHideConnectedPorts($event)"
+    matTooltipPosition="above"
     class="pointer-events-auto cursor-pointer text-sm text-gray-300 dark:text-white hover:text-blue-500 hover:dark:text-blue-500"></ng-icon>
 
   <!-- Delete Node Button-->
   <ng-icon *ngIf="!data.getDefinition().entry" (pointerdown)="onDeleteNode($event)" name="octTrash" size="18"
-    matTooltip="Delete Node" matTooltipPosition="above"
+    title="Delete Node" matTooltipPosition="above"
     class="pointer-events-auto cursor-pointer text-sm text-gray-300 dark:text-white hover:text-red-500 hover:dark:text-red-500"></ng-icon>
 </div>
 
@@ -33,7 +33,7 @@
       <span class="cid-label">{{getNodeLabel()}}</span>
     </div>
 
-    <span *ngIf="isGitHubAction()" class="cid-id">{{getNodeId()}}</span>
+    <span *ngIf="isGitHubAction()" class="cid-id" [title]="data.getType()">{{getNodeId()}}</span>
 
   </ng-container>
 </div>

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -29,7 +29,7 @@
                 <div *ngIf="nodes.size === 0">
                 </div>
                 <ul *ngIf="nodes.size > 0" class="cid-scrollbar">
-                    <li *ngFor="let node of nodes | keyvalue" (click)="onCreateNode($event, node.value)" (keyup)="0"
+                    <li *ngFor="let node of nodes | keyvalue" (click)="onCreateNode($event, node.key)" (keyup)="0"
                         tabindex="0" class="flex flex-col gap-y-1 cursor-pointer w-full px-2 py-2 cid-registry"
                         [title]="node.value.id + ' ' + node.value.description" matTooltipPosition="left"
                         matTooltipShowDelay="750">
@@ -40,7 +40,7 @@
 
                                 <div class="flex flex-row gap-x-2 justify-between">
                                     <span class="font-bold whitespace-nowrap cid-name">{{node.value.name}}</span>
-                                    <span class="truncate cid-description">{{getNodeTypeId(node.value)}}</span>
+                                    <span class="truncate cid-description">{{trimNodeUri(node.key)}}</span>
                                 </div>
 
                                 <p class="truncate cid-description" [title]="node.value.description">

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -31,7 +31,7 @@
                 <ul *ngIf="nodes.size > 0" class="cid-scrollbar">
                     <li *ngFor="let node of nodes | keyvalue" (click)="onCreateNode($event, node.value)" (keyup)="0"
                         tabindex="0" class="flex flex-col gap-y-1 cursor-pointer w-full px-2 py-2 cid-registry"
-                        [matTooltip]="node.value.id + ' ' + node.value.description" matTooltipPosition="left"
+                        [title]="node.value.id + ' ' + node.value.description" matTooltipPosition="left"
                         matTooltipShowDelay="750">
 
                         <div class="flex flex-row items-center">

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -56,14 +56,14 @@ export class SidebarComponent {
     }
   }
 
-  async onCreateNode(event: MouseEvent, nodeType: INodeTypeDefinitionBasic): Promise<void> {
+  async onCreateNode(event: MouseEvent, nodeTypeId: string): Promise<void> {
     event.preventDefault();
     event.stopPropagation();
 
-    await this.gs.createNode(nodeType.id, null, true);
+    await this.gs.createNode(nodeTypeId, null, true);
   }
 
-  getNodeTypeId(nodeType: INodeTypeDefinitionBasic): string {
-    return nodeType.id.substring('github.com/'.length);
+  trimNodeUri(nodeUri: string): string {
+    return nodeUri.substring('github.com/'.length);
   }
 }

--- a/src/app/helper/utils.ts
+++ b/src/app/helper/utils.ts
@@ -43,6 +43,7 @@ export interface RegistryUriInfo {
     registry: string;
     owner: string;
     regname: string;
+    hash: string;
     ref: string;
 }
 
@@ -54,9 +55,10 @@ export function uriToString(uri: RegistryUriInfo): string {
 
     r = `${r}${uri.owner}/${uri.regname}`;
 
-    if (uri.ref) {
-        r = `${r}@${uri.ref}`;
+    if (uri.hash) {
+        r = `${r}@${uri.hash}`;
     }
+
     return r;
 }
 
@@ -107,7 +109,6 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
         }
     }
 
-
     // As a fallback, if YAML failed, try to parse the node type uri
     // if it fits the format of[registry:]name/foo[@ref]
     const matches = uri.match(/^(([-.\w]+)\/)?([-\w]+)\/([-\w]+)((@([-.\w]+))?)$/);
@@ -120,6 +121,7 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
         registry: matches[2].toLowerCase(),
         owner: matches[3].toLowerCase(),
         regname: matches[4].toLowerCase(),
-        ref: matches[7].toLowerCase(),
+        hash: matches[7].toLowerCase(),
+        ref: '',
     };
 }

--- a/src/app/helper/utils.ts
+++ b/src/app/helper/utils.ts
@@ -43,7 +43,6 @@ export interface RegistryUriInfo {
     registry: string;
     owner: string;
     regname: string;
-    hash: string;
     ref: string;
 }
 
@@ -55,8 +54,8 @@ export function uriToString(uri: RegistryUriInfo): string {
 
     r = `${r}${uri.owner}/${uri.regname}`;
 
-    if (uri.hash) {
-        r = `${r}@${uri.hash}`;
+    if (uri.ref) {
+        r = `${r}@${uri.ref}`;
     }
 
     return r;
@@ -84,7 +83,7 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
 
     let allowFallback = true;
 
-    // If the uri is a Yaml file, check if it is from the github marketplace
+    // If the uri is a yaml string, check if it is from the github marketplace
     try {
         interface GitHubActionStep {
             name: string;
@@ -121,7 +120,6 @@ export function parseRegistryUri(uri: string): RegistryUriInfo {
         registry: matches[2].toLowerCase(),
         owner: matches[3].toLowerCase(),
         regname: matches[4].toLowerCase(),
-        hash: matches[7].toLowerCase(),
-        ref: '',
+        ref: matches[7].toLowerCase(),
     };
 }

--- a/src/app/schemas/graph.ts
+++ b/src/app/schemas/graph.ts
@@ -35,11 +35,6 @@ export interface INode {
     settings?: ISettings;
 }
 
-export interface IRegistry {
-    uri: string;
-    target: string;
-}
-
 export interface IExecution {
     src: {
         node: string;

--- a/src/app/schemas/graph.ts
+++ b/src/app/schemas/graph.ts
@@ -35,6 +35,11 @@ export interface INode {
     settings?: ISettings;
 }
 
+export interface IRegistry {
+    uri: string;
+    target: string;
+}
+
 export interface IExecution {
     src: {
         node: string;

--- a/src/app/services/gateway.service.ts
+++ b/src/app/services/gateway.service.ts
@@ -24,7 +24,7 @@ export class GatewayService {
                 ref: source.ref,
                 path: source.path,
             }, {
-                withCredentials: true
+                withCredentials: false
             });
             if (!graph) {
                 throw new Error(`graph ${source.owner} not found`);

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -110,9 +110,7 @@ export class GraphService {
               node: "gh-checkout",
             }
           }],
-          registries: [
-            "github.com/actions/checkout@v4"
-          ],
+          registries: [],
         };
       }
 
@@ -306,15 +304,25 @@ export class GraphService {
     return this.permission$.value;
   }
 
-  removeRegistry(registry: string): void {
+  removeRegistry(uri: string): void {
+    try {
+      parseRegistryUri(uri);
+    } catch (error) {
+      console.log(error);
+      return;
+    }
     const registries = this.graphRegistries$.value;
-    registries.delete(registry);
+    registries.delete(uri);
     this.graphRegistries$.next(registries);
   }
 
   addRegistry(uri: string): void {
-    parseRegistryUri(uri);
-
+    try {
+      parseRegistryUri(uri);
+    } catch (error) {
+      console.log(error);
+      return;
+    }
     const registries = this.graphRegistries$.value;
     registries.add(uri);
     this.graphRegistries$.next(registries);

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -93,7 +93,7 @@ export class GraphService {
               settings: undefined,
             },
             {
-              id: "gh-checkout-latest",
+              id: "gh-checkout",
               type: "github.com/actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11", // @v4.1.1
               inputs: {},
               position: { x: 450, y: 100 },

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -114,7 +114,8 @@ export class GraphService {
         };
       }
 
-      const prom = nr.loadBasicNodeTypeDefinitions(this.getRegistries());
+      const registries = new Set(g.registries);
+      const prom = nr.loadBasicNodeTypeDefinitions(registries);
 
       await cb(g);
 
@@ -123,7 +124,7 @@ export class GraphService {
       this.lastGraph = graph;
 
       this.graphEntry$.next(g.entry);
-      this.graphRegistries$.next(new Set(g.registries));
+      this.graphRegistries$.next(registries);
       this.permission$.next(writable ? Permission.Writable : Permission.ReadOnly);
     });
   }

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -79,7 +79,7 @@ export class GraphService {
       this.lastGraph = '';
 
       // Assume this is a new document if graph is empty and prefill with a trigger node
-      if (graph || Object.keys(graph).length === 0) {
+      if (graph === "" || Object.keys(g).length === 0) {
 
         g = {
           description: '',

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -94,7 +94,7 @@ export class GraphService {
             },
             {
               id: "gh-checkout-latest",
-              type: "github.com/actions/checkout",
+              type: "github.com/actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11", // @v4.1.1
               inputs: {},
               position: { x: 450, y: 100 },
               settings: undefined,

--- a/src/app/services/graph.service.ts
+++ b/src/app/services/graph.service.ts
@@ -8,7 +8,7 @@ import { IConnection, IExecution, IGraph, IInput, IOutput, INode } from '../sche
 import { NodeEditor } from 'rete';
 import { AreaExtra, Schemes, g_area, g_editor } from '../helper/rete/editor';
 import { AreaPlugin, NodeView } from 'rete-area-plugin';
-import { RegistryUriInfo, uriToString } from '../helper/utils';
+import { parseRegistryUri } from '../helper/utils';
 import { VsCodeService } from './vscode.service';
 import { Registry } from './registry.service';
 
@@ -80,35 +80,21 @@ export class GraphService {
 
       // Assume this is a new document if graph is empty and prefill with a trigger node
       if (graph || Object.keys(graph).length === 0) {
-        await nr.loadBasicNodeTypeDefinitions(new Set(["gh-start@v1"]));
-
-        const nodeGhStart = nr.findBasicNodeTypeDefinitionsSync((nodeId: string) => nodeId === "gh-start@v1");
-        if (!nodeGhStart) {
-          throw new Error("gh-start@v1 not found");
-        }
-
-        const nodeGhCheckout = nr.findBasicNodeTypeDefinitionsSync((nodeId: string) => nodeId.startsWith("github.com/actions/checkout"));
-        if (!nodeGhCheckout) {
-          throw new Error("github.com/actions/checkout not found");
-        }
-
-        const startNodeId = "gh-start";
-        const checkoutNodeId = "gh-checkout";
 
         g = {
           description: '',
-          entry: startNodeId,
+          entry: "gh-start",
           nodes: [
             {
-              id: startNodeId,
-              type: nodeGhStart.id,
+              id: "gh-start",
+              type: "gh-start@v1",
               inputs: {},
               position: { x: 100, y: 100 },
               settings: undefined,
             },
             {
-              id: checkoutNodeId,
-              type: nodeGhCheckout.id,
+              id: "gh-checkout-latest",
+              type: "github.com/actions/checkout",
               inputs: {},
               position: { x: 450, y: 100 },
               settings: undefined,
@@ -118,13 +104,15 @@ export class GraphService {
           executions: [{
             src: {
               port: "exec-on-push",
-              node: startNodeId,
+              node: "gh-start",
             }, dst: {
               port: "exec",
-              node: checkoutNodeId,
+              node: "gh-checkout",
             }
           }],
-          registries: [],
+          registries: [
+            "github.com/actions/checkout@v4"
+          ],
         };
       }
 
@@ -135,8 +123,9 @@ export class GraphService {
       await Promise.all([prom]);
 
       this.lastGraph = graph;
-      this.graphRegistries$.next(new Set(g.registries));
+
       this.graphEntry$.next(g.entry);
+      this.graphRegistries$.next(new Set(g.registries));
       this.permission$.next(writable ? Permission.Writable : Permission.ReadOnly);
     });
   }
@@ -245,9 +234,9 @@ export class GraphService {
 
     const graph: IGraph = {
       entry,
-      executions: executions,
-      connections: connections,
-      nodes: nodes,
+      executions,
+      connections,
+      nodes,
       registries: [...gs.getRegistries()],
       description,
     };
@@ -262,7 +251,7 @@ export class GraphService {
   }
 
   async createNode(nodeTypeId: string, nodeId: string | null, userCreated: boolean, inputs?: { [key: string]: IInput }, outputs?: { [key: string]: IOutput }): Promise<BaseNode> {
-    const sanitizedNodeId = nodeTypeId.replace(/[^a-zA-Z0-9-]/g, '-');
+    const sanitizedNodeId = nodeTypeId.replace(/[^a-zA-Z0-9-]/g, '-').replace(/^github.com-/, 'gh-')
 
     if (!nodeId) {
       nodeId = `${sanitizedNodeId}-${generateRandomWord(3)}`
@@ -323,17 +312,11 @@ export class GraphService {
     this.graphRegistries$.next(registries);
   }
 
-  addRegistry(registry: RegistryUriInfo): void {
-    // Caller has to make sure that all fields of the type uri are filled
-    if (registry.registry === ""
-      || registry.owner === ""
-      || registry.regname === ""
-    ) {
-      throw new Error("Invalid registry uri");
-    }
+  addRegistry(uri: string): void {
+    parseRegistryUri(uri);
 
     const registries = this.graphRegistries$.value;
-    registries.add(uriToString(registry));
+    registries.add(uri);
     this.graphRegistries$.next(registries);
   }
 

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -24,15 +24,15 @@ export class Registry {
     async loadBasicNodeTypeDefinitions(registryUris: Set<string>): Promise<void> {
         try {
             const nodeUris = [
-                "github.com/actions/cache@latest",
-                "github.com/actions/checkout@latest",
-                "github.com/actions/create-release@latest",
-                "github.com/actions/setup-dotnet@latest",
-                "github.com/actions/setup-go@latest",
-                "github.com/actions/setup-java@latest",
-                "github.com/actions/setup-node@latest",
-                "github.com/actions/setup-python@latest",
-                "github.com/actions/upload-artifact@latest",
+                "github.com/actions/cache",
+                "github.com/actions/checkout",
+                "github.com/actions/create-release",
+                "github.com/actions/setup-dotnet",
+                "github.com/actions/setup-go",
+                "github.com/actions/setup-java",
+                "github.com/actions/setup-node",
+                "github.com/actions/setup-python",
+                "github.com/actions/upload-artifact",
             ];
 
             for (const nodeUri of nodeUris) {

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -95,27 +95,6 @@ export class Registry {
         this.gs.addRegistry(uri);
     }
 
-    async resolveNodeTypeVersion(registryUrl: string): Promise<{ target: string }> {
-        try {
-            interface IVersion {
-                target: string;
-            }
-            const res = await this.yamlService.httpPost<IVersion>(`${environment.gatewayUrl}/api/v1/registry/nodedefs/resolve`, {
-                registry_uri: registryUrl
-            }, {
-                withCredentials: false
-            })
-
-            return { "target": res.target };
-        } catch (error) {
-            if (error instanceof HttpErrorResponse) {
-                throw new Error(error.error)
-            } else {
-                throw error;
-            }
-        }
-    }
-
     getBasicNodeTypeDefinitions(): Observable<Map<string, INodeTypeDefinitionBasic> | 'loading'> {
         return this.basicNodeTypeObservable$;
     }

--- a/src/app/services/registry.service.ts
+++ b/src/app/services/registry.service.ts
@@ -16,36 +16,40 @@ export class Registry {
     vscode = inject(VsCodeService);
     gs = inject(GraphService);
 
-    private partDefs = new BehaviorSubject<Map<string, INodeTypeDefinitionBasic> | 'loading'>('loading');
-    private basicNodeTypeObservable$ = this.partDefs.asObservable();
+    private basicDefs = new BehaviorSubject<Map<string, INodeTypeDefinitionBasic> | 'loading'>('loading');
+    private basicNodeTypeObservable$ = this.basicDefs.asObservable();
 
     private fullDefs = new Map<string, INodeTypeDefinitionFull>();
 
-    async loadBasicNodeTypeDefinitions(registryUrl: Set<string>): Promise<void> {
+    async loadBasicNodeTypeDefinitions(registryUris: Set<string>): Promise<void> {
         try {
-            // add some default registry urls
-            const registryUriCopy = new Set<string>(registryUrl);
-            // registryUriCopy.add("github.com/actions/cache");
-            registryUriCopy.add("github.com/actions/checkout");
-            registryUriCopy.add("github.com/actions/create-release");
-            registryUriCopy.add("github.com/actions/setup-dotnet");
-            registryUriCopy.add("github.com/actions/setup-go");
-            registryUriCopy.add("github.com/actions/setup-java");
-            registryUriCopy.add("github.com/actions/setup-node");
-            registryUriCopy.add("github.com/actions/setup-python");
-            registryUriCopy.add("github.com/actions/upload-artifact");
+            const nodeUris = [
+                "github.com/actions/cache@latest",
+                "github.com/actions/checkout@latest",
+                "github.com/actions/create-release@latest",
+                "github.com/actions/setup-dotnet@latest",
+                "github.com/actions/setup-go@latest",
+                "github.com/actions/setup-java@latest",
+                "github.com/actions/setup-node@latest",
+                "github.com/actions/setup-python@latest",
+                "github.com/actions/upload-artifact@latest",
+            ];
 
-            const nodeDefs = await this.yamlService.httpPost<INodeTypeDefinitionBasic[]>(`${environment.registryUrl}/api/v1/registry/nodedefs/basic`, {
-                registry_uris: [...registryUriCopy]
+            for (const nodeUri of nodeUris) {
+                registryUris.add(nodeUri);
+            }
+
+            const nodeDefs = await this.yamlService.httpPost<INodeTypeDefinitionBasic[]>(`${environment.gatewayUrl}/api/v1/registry/nodedefs/basic`, {
+                registry_uris: [...registryUris]
             }, {
                 withCredentials: false
             })
 
             const defs = new Map<string, INodeTypeDefinitionBasic>();
-            for (const nodeDef of Object.values(nodeDefs)) {
-                defs.set(nodeDef.id, nodeDef);
+            for (const [nodeUri, nodeDef] of Object.entries(nodeDefs)) {
+                defs.set(nodeUri, nodeDef);
             }
-            this.partDefs.next(defs);
+            this.basicDefs.next(defs);
         } catch (error) {
             if (error instanceof HttpErrorResponse) {
                 throw new Error(error.error)
@@ -54,30 +58,21 @@ export class Registry {
             }
         }
     }
-    async loadRegistry(uri: string): Promise<void> {
-        const registries = this.gs.getRegistriesCopy();
-        const uriInfo: RegistryUriInfo = parseRegistryUri(uri);
-        if (!uriInfo.hash) {
-            const { target } = await this.resolveNodeTypeVersion(uriToString(uriInfo));
-            uriInfo.hash = target;
-        }
-        registries.add(uriToString(uriInfo));
 
-        await this.loadBasicNodeTypeDefinitions(registries);
-        this.gs.addRegistry(uriInfo);
-    }
-
-    async loadFullNodeTypeDefinitions(registryUrl: Set<string>): Promise<void> {
+    async loadFullNodeTypeDefinitions(registryUris: Set<string>): Promise<void> {
         try {
-            const nodeDefs = await this.yamlService.httpPost<INodeTypeDefinitionFull[]>(`${environment.registryUrl}/api/v1/registry/nodedefs/full`, {
-                registry_uris: [...registryUrl]
+            const nodeDefs = await this.yamlService.httpPost<INodeTypeDefinitionFull[]>(`${environment.gatewayUrl}/api/v1/registry/nodedefs/full`, {
+                registry_uris: [...registryUris],
             }, {
                 withCredentials: false
             })
 
             const defs = new Map<string, INodeTypeDefinitionFull>();
-            for (const nodeDef of Object.values(nodeDefs)) {
-                defs.set(nodeDef.id, nodeDef);
+            for (const [nodeUri, nodeDef] of this.fullDefs) {
+                defs.set(nodeUri, nodeDef);
+            }
+            for (const [nodeUri, nodeDef] of Object.entries(nodeDefs)) {
+                defs.set(nodeUri, nodeDef);
             }
             this.fullDefs = defs;
         } catch (error: unknown) {
@@ -87,6 +82,17 @@ export class Registry {
                 throw error;
             }
         }
+    }
+
+    async loadRegistry(uri: string): Promise<void> {
+        const ruri: RegistryUriInfo = parseRegistryUri(uri);
+        uri = uriToString(ruri);
+
+        const registries = this.gs.getRegistriesCopy();
+        registries.add(uri);
+        await this.loadBasicNodeTypeDefinitions(registries);
+
+        this.gs.addRegistry(uri);
     }
 
     async resolveNodeTypeVersion(registryUrl: string): Promise<{ target: string }> {
@@ -115,11 +121,11 @@ export class Registry {
     }
 
     findBasicNodeTypeDefinitionsSync(matchFn: (nodeId: string) => boolean): INodeTypeDefinitionBasic | null {
-        if (this.partDefs.value === 'loading') {
+        if (this.basicDefs.value === 'loading') {
             throw new Error('Basic node type definitions are still loading');
         }
 
-        for (const [k, v] of this.partDefs.value) {
+        for (const [k, v] of this.basicDefs.value) {
             if (matchFn(k)) {
                 return v;
             }


### PR DESCRIPTION
💡  This PR defines the way how versions of GH action are handled in the action graph, making them **much** safer. Prior to these changes the behaviour was undefined. These changes come in tandem with updates to the API gateway.

Each action graph can have one or more so-called `registries`, basically node URIs that point to a location where a GH action is stored (e.g: `https://github.com/actions/checkout@v1`).

<img width="300" src="https://github.com/actionforge/graph-editor/assets/12844423/663b6cef-d874-4b2e-ade3-cae5cb5001b3">

The term *registries* is currently preferred as for the future the node types at these locations don't necessarily have to be a GitHub action.

Once the user added has added the node uri to the registry collection, it is saved as-is. Supported URIs can be links from the [GH Marketplace](https://github.com/marketplace/actions/setup-net-core-sdk?version=v4.0.0) or links to the github URL with an optional `@whatever` to specify the corresponding ref. 

<img width="500" src="https://github.com/actionforge/graph-editor/assets/12844423/90d4283a-4014-4e36-8c7c-1401bd493afe">

When the user creates a node from the sidebar of the editor, the node definition for the GH action file is pulled from the API gateway by providing the associated node uri. The server determines the version and the node is added with its **git hash** to the action graph.

> [!NOTE]
> This means that the user does NOT need to provide a specific action hash themselves`github.com/actions/checkout@abcdefg...`, the editor does this now.

The graph file then looks like this with a user provided node uri to `github.com/docker/build-push-action@v5.1.0` but then with a pinned node.

<img width="600" src="https://github.com/actionforge/graph-editor/assets/12844423/81945803-a8e2-46d5-ae6a-830edfb97fd6">

The API gateway will resolve and determine provided refs as follows:

### 1. `<empty>` or `@latest`

- commit hash of the latest public release, or latest commit hash on default branch if no

### 2. `@v[0-9]+`

- commit hash of the public release with the highest minor and patch version, e.g. `@v3` =>  `@v3.6.2`  => `0abc...`

### 3. `@v[0-9]+.[0-9]+`

- commit hash of the public release with the highest patch version, e.g. `@v3.2` => `@v3.2.4`

### 4. `^(?!v).+` (any branch or tag ref not starting with `v`)

- commit hash of the associated branch or tag ref


## :bug: Additional changes are fixing UI and tooltip bugs